### PR TITLE
Fix multiple checkins

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -69,7 +69,9 @@ router.patch('/users/:userID', (req, res, next) => {
 router.post('/users/:userID/checkIn', (req, res, next) => {
   req.db.UserModel.findOne({ id: req.params.userID })
     .then(user => {
-      user.checkIns.push({ pubName: req.body.pubName });
+      if (user.checkIns.filter(ci => ci.pubName === req.body.pubName).length === 0) {
+        user.checkIns.push({ pubName: req.body.pubName });
+      }
       return user.save()
     })
     .then(data => res.json(data))

--- a/src/api.js
+++ b/src/api.js
@@ -69,7 +69,7 @@ router.patch('/users/:userID', (req, res, next) => {
 router.post('/users/:userID/checkIn', (req, res, next) => {
   req.db.UserModel.findOne({ id: req.params.userID })
     .then(user => {
-      if (user.checkIns.filter(ci => ci.pubName === req.body.pubName).length === 0) {
+      if (!user.checkIns.some(ci => ci.pubName === req.body.pubName)) {
         user.checkIns.push({ pubName: req.body.pubName });
       }
       return user.save()


### PR DESCRIPTION
# Summary

There was a previous issue whereby users could checkin more than once to a single pub. This fix makes it so that existence of a checkin is verified before a new checkin is added. This is more of a quickfix and will need to be updated when the route store is moved.

# How to verify

* Attempt to check in to a pub twice. You can't.

* No tests yet.

# Backwards compatibility

Yes.