### PR TITLE
Revert branding back to Circle Line Pub Crawl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pub-crawl-tool
-##### A web app for tracking progress & points on the 2018 Glasgow Sub Crawl.
+##### A web app for tracking progress & points on the 2018 circle line pub crawl.
 
-This web app allows for tracking you and your fellow crawlers through the Glasgow Sub Crawl.
+This web app allows for tracking you and your fellow crawlers through the circle line pub crawl.
 For a bit of fun, we also had point penalties for things (e.g. losing something) on
 our pub crawl. This tool was created by me in about 14 hours to track those points (and an additional 6 hours for adding the tracking feature & deploying v2).
 
@@ -29,4 +29,4 @@ Thanks to Stephen Hutchings for the user icon https://www.iconfinder.com/icons/2
 
 #### Tags
 
-pub crawl, points tracker, circle line, glasgow sub
+pub crawl, points tracker, circle line

--- a/src/app.html
+++ b/src/app.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>Glasgow Sub Crawl</title>
+  <title>Circle Line Pub Crawl</title>
 
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -31,7 +31,7 @@
 
 </head>
 <body>
-  <header><a href="/">Glasgow Sub Crawl</a></header>
+  <header><a href="/">Circle Line Pub Crawl</a></header>
   <main id="app"></main>
   <script src="/build/bundle.js"></script>
 </body>

--- a/src/components/WelcomePage.vue
+++ b/src/components/WelcomePage.vue
@@ -1,7 +1,7 @@
 <template>
   <article>
   	<h1>Welcome</h1>
-      <p>Welcome to the official Glasgow Sub Crawl app. This app will serve as your guide for the crawl and is where you'll be recording penalty points.</p>
+      <p>Welcome to the official Circle Line Pub Crawl app. This app will serve as your guide for the crawl and is where you'll be recording penalty points.</p>
       <form v-if="currentUser.checkIns.length === 0" >
         <label>Please select the pub you're starting from: 
           <select v-model="selectedPub">

--- a/static/images/favicon/manifest.json
+++ b/static/images/favicon/manifest.json
@@ -1,5 +1,5 @@
 {
- "name": "Glasgow Sub Crawl",
+ "name": "Circle Line Pub Crawl",
  "icons": [
   {
    "src": "\/android-icon-36x36.png",

--- a/static/styles/styles.css
+++ b/static/styles/styles.css
@@ -29,7 +29,7 @@ header {
   box-sizing: border-box;
   padding: 8px;
 
-  background: rgb(238, 121, 19);
+  background: #EE6352;
   width: 100%;
 }
 


### PR DESCRIPTION
Branding was changed for the Glasgow Sub Crawl in October 2018.

This commit reverts the branding back to the original Circle Line colours and wording.